### PR TITLE
[pby] 220222 그리디

### DIFF
--- a/BOJ/13305.py
+++ b/BOJ/13305.py
@@ -1,0 +1,30 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+km = list(map(int, input().split()))
+oil = list(map(int, input().split()))
+num, price, result = km[0], oil[0], 0
+
+for i in range(n-1):
+    # 지금까지 나온 주유값이 이번 주유값보다 작으면
+    if price <= oil[i]:
+        # 가야하는 km를 더함
+        if i != 0 and i <= len(km)-1:
+            num += km[i]
+    else:
+        # 거리와 가격을 곱해서 더함
+        result += num * price
+
+        # 현재 갈 거리와 기름값으로 초기화함
+        if i <= len(km)-1:
+            num = km[i]
+        if i <= len(oil)-1:
+            price = oil[i]
+
+    # 마지막으로 거리와 가격을 곱해서 더함
+    if i == n-2:
+        result += num * price
+
+# 비용 출력
+print(result)

--- a/BOJ/20365.py
+++ b/BOJ/20365.py
@@ -1,0 +1,36 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+color = list(input())
+# 마지막 요소로 개행문자가 들어가서 삭제함
+color.pop()
+
+# 색상이 몇 번 연속되었는지, 같은 색상의 묶음이 몇 개인지, 최종 답안
+countR, countB, red, blue, result = 0, 0, 0, 0, 0
+
+for c in color:
+    if c == 'R':
+        countB = 0
+        
+        if countR > 0:
+            countR += 1
+        else:
+            red += 1
+            countR += 1
+            
+    elif c == 'B':
+        countR = 0
+        
+        if countB > 0:
+            countB += 1
+        else:
+            blue += 1
+            countB += 1
+
+if red >= blue:
+    result = blue + 1
+else:
+    result = red + 1
+    
+print(result)


### PR DESCRIPTION
### :computer: 풀이 기록
**13305 주유소**
- 풀이 시간 | 62분
- 링크 | https://www.acmicpc.net/problem/13305
- 다른 블로그 풀이 | https://alpyrithm.tistory.com/134

> 초기 설정
> - 처음 도시에서는 무조건 기름을 구매해야 한다.
> - 현재 도시와 앞으로 갈 도시의 주유값을 비교해서 더 저렴하면 앞으로 갈 도시 도시에서 그다음 도시까지 갈 수 있도록 더 많이 산다.

> 구현 중 (해결 or 실패한 방법)
> - 초기 설정대로 풀면 되겠다고 생각했으나 가장 주유값이 저렴한 곳에서 주유해야 한다는 것을 잊고 앞뒤로만 비교해서 푸는 데 오래 걸렸다.

> 코드 리뷰 (새로 배운 것 or 안되고 막혔던 것)
> - 다른 분의 풀이를 보니 for문을 더 간략하게 사용할 수도 있고 나온 주유값 중에 저렴한 주유소가 있다면 주유하는 깔끔한 풀이 방식도 있다.